### PR TITLE
add pgRouting + README improvement

### DIFF
--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -2,6 +2,6 @@ FROM postgres:9.5
 MAINTAINER Camptocamp "info@camptocamp.com"
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y postgresql-9.5-postgis-2.2 postgresql-9.5-postgis-2.2-scripts postgresql-contrib-9.5 \
+  && apt-get install --no-install-recommends -y postgresql-9.5-postgis-2.3 postgresql-9.5-postgis-2.3-scripts postgresql-contrib-9.5 postgresql-9.5-pgrouting \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/9.6/Dockerfile
+++ b/9.6/Dockerfile
@@ -2,6 +2,6 @@ FROM postgres:9.6
 MAINTAINER Camptocamp "info@camptocamp.com"
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y postgresql-9.6-postgis-2.3 postgresql-9.6-postgis-2.3-scripts postgresql-contrib-9.6 \
+  && apt-get install --no-install-recommends -y postgresql-9.6-postgis-2.3 postgresql-9.6-postgis-2.3-scripts postgresql-contrib-9.6 postgresql-9.6-pgrouting \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Camptocamp's PostgreSQL Docker container
 
-The tags are named after the PostgreSQL versions:
+This image extends the [official PostgreSQL image](https://hub.docker.com/_/postgres/) with the following features:
 
-* PostgreSQL 9.4 is using PostGIS 2.1,
-* PostgreSQL 9.5 is using PostGIS 2.2,
-* PostgreSQL 9.6 is using PostGIS 2.3.
+- [PostGIS](http://postgis.net/)
+- [pgRouting](http://pgrouting.org/)
+- [PostgreSQL contrib package](https://packages.debian.org/sid/postgresql-contrib-9.6)
 
 See the PostgreSQL image documentation for more details:
 https://hub.docker.com/_/postgres/


### PR DESCRIPTION
The pgrouting package available on apt.postgresql.org has a
dependency on PostGIS version 2.3.