### PR TITLE
postgresql 10 with postgis 2.4

### DIFF
--- a/10.0/Dockerfile
+++ b/10.0/Dockerfile
@@ -1,0 +1,12 @@
+FROM postgres:10.0
+
+RUN apt-get update \
+  && for POSTGIS_VERSION in 2.4; do \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    postgresql-contrib \
+    postgresql-$PG_MAJOR-postgis-$POSTGIS_VERSION \
+    postgresql-$PG_MAJOR-postgis-$POSTGIS_VERSION-scripts \
+    postgresql-$PG_MAJOR-pgrouting; \
+    done \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
postgis 2.4 for older postgresql versions are builded again GEOS 3.4 but some functions like ST_VoronoiPolygons need GEOS >=3.5.0