### PR TITLE
Remove unsupported pg and postgis version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,29 +9,20 @@ define build-image
 	$(if ${PUSH_GHCR},docker push ghcr.io/camptocamp/postgres:${1}-postgis-$(subst $(space),-,${2}),)
 endef
 
-all: 9.4 9.5 9.6 10 11 12 13
+all: 9.6 10 11 12 13
 
-9.4:
-	$(call build-image,"9.4","2.3 2.4 2.5")
-
-9.5:
-	$(call build-image,"9.5","2.3 2.4 2.5")
-	$(call build-image,"9.5","3")
 
 9.6:
-	$(call build-image,"9.6","2.3")
+	$(call build-image,"9.6","3")
 
 10:
-	$(call build-image,"10","2.4")
+	$(call build-image,"10","4")
 
 11:
-	$(call build-image,"11","2.5")
 	$(call build-image,"11","3")
 
 12:
-	$(call build-image,"12","2.5")
 	$(call build-image,"12","3")
 
 13:
-	$(call build-image,"13","2.5")
 	$(call build-image,"13","3")

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ all: 9.6 10 11 12 13
 
 
 9.6:
-	$(call build-image,"9.6","3")
+	$(call build-image,"9.6","2.3")
 
 10:
-	$(call build-image,"10","4")
+	$(call build-image,"10","2.4")
 
 11:
 	$(call build-image,"11","3")


### PR DESCRIPTION
pgdg now include only postgis3 builds.